### PR TITLE
Fix project API's

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -167,7 +167,7 @@ PlayerSettings:
   applicationIdentifier: {}
   buildNumber: {}
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 19
+  AndroidMinSdkVersion: 28
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
@@ -311,7 +311,7 @@ PlayerSettings:
     m_GraphicsJobMode: 0
   m_BuildTargetGraphicsAPIs:
   - m_BuildTarget: AndroidPlayer
-    m_APIs: 150000000b000000
+    m_APIs: 0b000000
     m_Automatic: 0
   - m_BuildTarget: iOSSupport
     m_APIs: 10000000


### PR DESCRIPTION
Removed Vulkan API
Set what seems to be the correct Android versions/API Level.

This small change has great impact on the size of hats, it can decrease the shader size by 75% or more.
![](https://i.imgur.com/D49i4BV.png)
![](https://i.imgur.com/p4lYlKc.png)
Idk why PC went down a few bits but mostly the Android files are halved.
![](https://i.imgur.com/4DCcXfx.png)
Top is Android, bottom PC. Left is the old settings, right is the new settings.


It's a small change but it can reduce the file-size and shorten compilation times.
Its one of those things that stacks up over time.